### PR TITLE
chore: return proper error

### DIFF
--- a/pkg/textextraction/extract.go
+++ b/pkg/textextraction/extract.go
@@ -33,6 +33,9 @@ func BytesToText(contents []byte, contentType string) (string, error) {
 		case "text/html":
 			return html2text.FromString(string(contents), html2text.Options{TextOnly: true})
 		default:
+			if err != nil {
+				return "", err
+			}
 			return "", errors.New("unsupported content type")
 		}
 	}


### PR DESCRIPTION
Because

- we are not returning a proper error in case of error in `docconv.Convert`

This commit

- adds code change to return the proper error
