### PR TITLE
chore: return content type with error

### DIFF
--- a/pkg/textextraction/extract.go
+++ b/pkg/textextraction/extract.go
@@ -36,7 +36,7 @@ func BytesToText(contents []byte, contentType string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return "", errors.New("unsupported content type")
+			return "", errors.New("unsupported content type" + contentType)
 		}
 	}
 	return res.Body, nil

--- a/pkg/textextraction/extract.go
+++ b/pkg/textextraction/extract.go
@@ -36,7 +36,7 @@ func BytesToText(contents []byte, contentType string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return "", errors.New("unsupported content type" + contentType)
+			return "", errors.New("unsupported content type: " + contentType)
 		}
 	}
 	return res.Body, nil


### PR DESCRIPTION
Because

- we need the error to be more descriptive

This commit

- adds code change to return content type with error
