### PR TITLE
chore: use base64 encoding for file contents

### DIFF
--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -65,7 +65,7 @@ func TestTextExtraction(t *testing.T) {
 	path := "test_artifacts/resume.pdf"
 	file, _ := ioutil.ReadFile(path)
 	fileReq := textextraction.FromFile{
-		FileContents: string(file),
+		FileContents: base64.Encode(string(file)),
 		ContentType:  "application/pdf",
 	}
 	var in structpb.Struct

--- a/pkg/textextraction/config/definitions.json
+++ b/pkg/textextraction/config/definitions.json
@@ -121,7 +121,7 @@
                                   "type": "string"
                                 },
                                 "file_contents": {
-                                  "title": "File Contents",
+                                  "title": "File Contents (base64 encoded string)",
                                   "type": "string"
                                 },
                                 "task": {

--- a/pkg/textextraction/extract.go
+++ b/pkg/textextraction/extract.go
@@ -27,19 +27,18 @@ func BytesToText(contents []byte, contentType string) (string, error) {
 		return "", errors.New("empty content")
 	}
 	res, err := docconv.Convert(bytes.NewReader(contents), contentType, true)
-	if err != nil || res == nil || len(res.Body) == 0 {
-		//fallbacks
-		switch contentType {
-		case "text/html":
-			return html2text.FromString(string(contents), html2text.Options{TextOnly: true})
-		default:
-			if err != nil {
-				return "", err
-			}
-			return "", errors.New("unsupported content type: " + contentType)
-		}
+	if res != nil && len(res.Body) > 0 {
+		return res.Body, nil
 	}
-	return res.Body, nil
+	//fallbacks
+	switch contentType {
+	case "text/html":
+		return html2text.FromString(string(contents), html2text.Options{TextOnly: true})
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", errors.New("unsupported content type: " + contentType)
 }
 
 func PathToText(path string) (string, error) {

--- a/pkg/textextraction/main.go
+++ b/pkg/textextraction/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/component/pkg/configLoader"
+	"github.com/instill-ai/operator/pkg/base64"
 )
 
 const (
@@ -115,6 +116,10 @@ func (c *Operation) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 		case taskExtractFromFile:
 			obj := FromFile{}
 			err := base.ConvertFromStructpb(input, &obj)
+			if err != nil {
+				return nil, err
+			}
+			obj.FileContents, err = base64.Decode(obj.FileContents)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Because

- directly using file contents in text extraction operator has issues due to protobuf structs

This commit

- used base64 encoding for file contents in text extraction operator
