### PR TITLE
refactor(base64,json): refactor base64 and json operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	code.sajari.com/docconv v1.3.7
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/component v0.5.0-alpha.0.20231011164605-745a8446e5bd
+	github.com/instill-ai/component v0.5.0-alpha.0.20231011175850-6e15dc306543
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9Pq
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/araddon/dateparse v0.0.0-20180729174819-cfd92a431d0e/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 h1:TEBmxO80TM04L8IuMWk77SGL1HomBmKTdzdJLLWznxI=
 github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
@@ -37,10 +36,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
-github.com/instill-ai/component v0.5.0-alpha.0.20231009140320-4a7e8ba84a93 h1:sjrAMMWzfU+kNqROQSX21+LT4ANKURuSp7hiDnDZGBA=
-github.com/instill-ai/component v0.5.0-alpha.0.20231009140320-4a7e8ba84a93/go.mod h1:eiGvlNBPqac2oWv83KKIlXJRI7VykcSQkQ9amK4KQVs=
-github.com/instill-ai/component v0.5.0-alpha.0.20231011164605-745a8446e5bd h1:XD0JN8VzdhcgaHVhgnFCKRZIqJB20U8nC+UMmKdGttY=
-github.com/instill-ai/component v0.5.0-alpha.0.20231011164605-745a8446e5bd/go.mod h1:eiGvlNBPqac2oWv83KKIlXJRI7VykcSQkQ9amK4KQVs=
+github.com/instill-ai/component v0.5.0-alpha.0.20231011175850-6e15dc306543 h1:8urmgKRqek0lwRQ2WhB1Xpm2aIOn/2LTFg3ZdQlcTTA=
+github.com/instill-ai/component v0.5.0-alpha.0.20231011175850-6e15dc306543/go.mod h1:eiGvlNBPqac2oWv83KKIlXJRI7VykcSQkQ9amK4KQVs=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231009130709-dfa678a1ed2b h1:6ytmj7AeVAFW6KE+WJE7z3M/4sOpRdkoh3s+gzKZTfw=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231009130709-dfa678a1ed2b/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
@@ -70,7 +67,6 @@ github.com/richardlehane/mscfb v1.0.3/go.mod h1:YzVpcZg9czvAuhk9T+a3avCpcFPMUWm7
 github.com/richardlehane/msoleps v1.0.1/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
 github.com/richardlehane/msoleps v1.0.3 h1:aznSZzrwYRl3rLKRT3gUk9am7T/mLNSnJINvN0AQoVM=
 github.com/richardlehane/msoleps v1.0.3/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
-github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/simplereach/timeutils v1.2.0/go.mod h1:VVbQDfN/FHRZa1LSqcwo4kNZ62OOyqLLGQKYB3pB0Q8=
@@ -84,7 +80,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
@@ -105,7 +100,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc h1:8DyZCyvI8mE1IdLy/60bS+52xfymkE72wv1asokgtao=
 google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:xZnkP7mREFX5MORlOPEzLMr+90PPZQ2QWzrVTWfAq64=
 google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc h1:kVKPf/IiYSBWEWtkIn6wZXwWGCnLKcC8oWfZvXjsGnM=

--- a/pkg/base64/encoding_test.go
+++ b/pkg/base64/encoding_test.go
@@ -18,11 +18,6 @@ func TestEncode(t *testing.T) {
 			Input:          "Hello, World!",
 			ExpectedOutput: "SGVsbG8sIFdvcmxkIQ==",
 		},
-		{
-			Name:           "already encoded string",
-			Input:          "SGVsbG8sIFdvcmxkIQ==",
-			ExpectedOutput: "SGVsbG8sIFdvcmxkIQ==",
-		},
 	}
 
 	for _, test := range tests {

--- a/pkg/base64/main.go
+++ b/pkg/base64/main.go
@@ -97,11 +97,6 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 }
 
 func Encode(str string) string {
-	_, err := base64.StdEncoding.DecodeString(str)
-	if err == nil {
-		//already encoded
-		return str
-	}
 	return base64.StdEncoding.EncodeToString([]byte(str))
 }
 

--- a/pkg/json/config/definitions.json
+++ b/pkg/json/config/definitions.json
@@ -1,7 +1,8 @@
 [
   {
     "available_tasks": [
-      "TASK_GET_VALUE"
+      "TASK_MARSHAL",
+      "TASK_UNMARSHAL"
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/vdp/operators/json",

--- a/pkg/json/config/tasks.json
+++ b/pkg/json/config/tasks.json
@@ -1,30 +1,64 @@
 {
-  "TASK_GET_VALUE": {
+  "TASK_MARSHAL": {
     "input": {
       "properties": {
-        "json_string": {
-          "title": "JSON String",
-          "type": "string"
-        },
-        "path": {
-          "title": "Path",
-          "type": "string"
+        "object": {
+          "instillFormat": "object",
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Object",
+          "type": "object"
         }
       },
       "required": [
-        "path",
-        "json_string"
+        "object"
       ],
       "type": "object"
     },
     "output": {
       "properties": {
-        "result": {
-          "title": "Result"
+        "string": {
+          "instillFormat": "text",
+          "title": "Data",
+          "type": "string"
         }
       },
       "required": [
-        "result"
+        "string"
+      ],
+      "type": "object"
+    }
+  },
+  "TASK_UNMARSHAL": {
+    "input": {
+      "properties": {
+        "string": {
+          "instillFormat": "text",
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "required": [
+        "string"
+      ],
+      "type": "object"
+    },
+    "output": {
+      "properties": {
+        "object": {
+          "instillFormat": "object",
+          "title": "Object",
+          "type": "object"
+        }
+      },
+      "required": [
+        "object"
       ],
       "type": "object"
     }


### PR DESCRIPTION
Because

- we need to support marshal and unmarshal functions in json operator
- there is a bug in base64 encoder

This commit

- re-implement json operator to support marshal and unmarshal functions
- fix base64 encode issue
- update json-schema
