### PR TITLE
chore(instillFormat): remove `text/*` format

### DIFF
--- a/pkg/base64/config/tasks.json
+++ b/pkg/base64/config/tasks.json
@@ -10,8 +10,7 @@
         "data": {
           "description": "Base64 string to be decoded",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -37,7 +36,7 @@
       "properties": {
         "data": {
           "description": "Data",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Data",
           "type": "string"
@@ -61,8 +60,7 @@
         "data": {
           "description": "Data to be encoded",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -88,7 +86,7 @@
       "properties": {
         "data": {
           "description": "Data",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Data",
           "type": "string"

--- a/pkg/downloadurl/config/tasks.json
+++ b/pkg/downloadurl/config/tasks.json
@@ -10,8 +10,7 @@
         "url": {
           "description": "URL to be downloaded",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -38,7 +37,7 @@
       "properties": {
         "text": {
           "description": "Text",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Text",
           "type": "string"

--- a/pkg/image/config/tasks.json
+++ b/pkg/image/config/tasks.json
@@ -7,8 +7,7 @@
         "category": {
           "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/classification/properties/category",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUpstreamTypes": [
             "value",

--- a/pkg/json/config/tasks.json
+++ b/pkg/json/config/tasks.json
@@ -37,7 +37,7 @@
       "properties": {
         "string": {
           "description": "Data",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Data",
           "type": "string"
@@ -61,8 +61,7 @@
         "string": {
           "description": "Json string to be unmarshaled",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [

--- a/pkg/textextraction/config/tasks.json
+++ b/pkg/textextraction/config/tasks.json
@@ -11,8 +11,7 @@
         "content_type": {
           "description": "Content type",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -25,8 +24,7 @@
         "file_contents": {
           "description": "File contents (base64 encoded string)",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
@@ -53,7 +51,7 @@
       "properties": {
         "text": {
           "description": "Text",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Text",
           "type": "string"
@@ -77,8 +75,7 @@
         "path": {
           "description": "File URL path",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -105,7 +102,7 @@
       "properties": {
         "text": {
           "description": "Text",
-          "instillFormat": "text/plain",
+          "instillFormat": "string",
           "instillUIOrder": 0,
           "title": "Text",
           "type": "string"


### PR DESCRIPTION
Because

- the `text/*` should be in binary format for data movement, it can not be used together with primitive `string` format.

This commit

- remove `text/*` in `instillFormat` and `instillAcceptFormats`
