### PR TITLE
feat(text): add support for text operator task tokenizer splitter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/instill-ai/component v0.6.1-alpha.0.20231109121032-f720e8d61ce7
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
-	github.com/stretchr/testify v1.8.1
+	github.com/pkoukk/tiktoken-go v0.1.6
+	github.com/stretchr/testify v1.8.2
 	go.uber.org/zap v1.26.0
 	golang.org/x/image v0.13.0
 	google.golang.org/protobuf v1.31.0
@@ -22,12 +23,14 @@ require (
 	github.com/andybalholm/cascadia v1.2.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/fatih/set v0.2.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
 	github.com/go-resty/resty/v2 v2.3.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 // indirect
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f // indirect
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1/go.mod h1:SLqhdZ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
@@ -42,6 +44,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/instill-ai/component v0.6.1-alpha.0.20231109121032-f720e8d61ce7 h1:LVOzuK+jmXzmiLOtV4KL7qGGGS5x8F8R9Ck/GUajQEs=
@@ -78,6 +82,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
+github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/richardlehane/mscfb v1.0.3 h1:rD8TBkYWkObWO0oLDFCbwMeZ4KoalxQy+QgniCj3nKI=
@@ -98,8 +104,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/pkg/base64/config/definitions.json
+++ b/pkg/base64/config/definitions.json
@@ -5,7 +5,7 @@
       "TASK_DECODE"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/base64",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/base64",
     "icon": "base64.svg",
     "icon_url": "",
     "id": "op-base64",

--- a/pkg/downloadurl/config/definitions.json
+++ b/pkg/downloadurl/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_DOWNLOAD_BASE64"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/download",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/download",
     "icon": "download.svg",
     "icon_url": "",
     "id": "op-download",

--- a/pkg/end/config/definitions.json
+++ b/pkg/end/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_END"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/op-end",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/op-end",
     "icon": "op-end.svg",
     "icon_url": "",
     "id": "op-end",

--- a/pkg/image/config/definitions.json
+++ b/pkg/image/config/definitions.json
@@ -9,7 +9,7 @@
       "TASK_DRAW_SEMANTIC_SEGMENTATION"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/image",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/image",
     "icon": "image.svg",
     "icon_url": "",
     "id": "op-image",

--- a/pkg/json/config/definitions.json
+++ b/pkg/json/config/definitions.json
@@ -5,7 +5,7 @@
       "TASK_UNMARSHAL"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/json",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/json",
     "icon": "json.svg",
     "icon_url": "",
     "id": "op-json",

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/instill-ai/operator/pkg/image"
 	"github.com/instill-ai/operator/pkg/json"
 	"github.com/instill-ai/operator/pkg/start"
+	"github.com/instill-ai/operator/pkg/text"
 	"github.com/instill-ai/operator/pkg/textextraction"
 )
 
@@ -41,6 +42,7 @@ func Init(logger *zap.Logger) base.IOperator {
 		// operator.(*Operator).ImportDefinitions(rest.Init(logger))
 		operator.(*Operator).ImportDefinitions(downloadurl.Init(logger))
 		operator.(*Operator).ImportDefinitions(image.Init(logger))
+		operator.(*Operator).ImportDefinitions(text.Init(logger))
 
 	})
 	return operator

--- a/pkg/rest/config/definitions.json
+++ b/pkg/rest/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_CALL_ENDPOINT"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/rest",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/rest",
     "icon": "rest.svg",
     "icon_url": "",
     "id": "op-rest",

--- a/pkg/start/config/definitions.json
+++ b/pkg/start/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_START"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/op-start",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/op-start",
     "icon": "op-start.svg",
     "icon_url": "",
     "id": "op-start",

--- a/pkg/text/config/definitions.json
+++ b/pkg/text/config/definitions.json
@@ -1,0 +1,16 @@
+[
+  {
+    "available_tasks": [
+      "TASK_TOKENIZER_SPLITTER"
+    ],
+    "custom": false,
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/text",
+    "icon": "text.svg",
+    "icon_url": "",
+    "id": "op-text",
+    "public": true,
+    "spec": {},
+    "title": "Text",
+    "uid": "5b7aca5b-1ae3-477f-bf60-d34e1c993c87"
+  }
+]

--- a/pkg/text/config/tasks.json
+++ b/pkg/text/config/tasks.json
@@ -1,0 +1,137 @@
+{
+  "TASK_TOKENIZER_SPLITTER": {
+    "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "text"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "chunk_token_size": {
+          "default": 500,
+          "description": "Number of tokens per text chunk",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "minimum": 1,
+          "title": "Chunk Token Size",
+          "type": "integer"
+        },
+        "model": {
+          "description": "ID of the model to use for tokenization",
+          "enum": [
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "text-davinci-003",
+            "text-davinci-002",
+            "text-davinci-001",
+            "text-curie-001",
+            "text-babbage-001",
+            "text-ada-001",
+            "davinci",
+            "curie",
+            "babbage",
+            "ada",
+            "code-davinci-002",
+            "code-davinci-001",
+            "code-cushman-002",
+            "code-cushman-001",
+            "davinci-codex",
+            "cushman-codex",
+            "text-davinci-edit-001",
+            "code-davinci-edit-001",
+            "text-embedding-ada-002",
+            "text-similarity-davinci-001",
+            "text-similarity-curie-001",
+            "text-similarity-babbage-001",
+            "text-similarity-ada-001",
+            "text-search-davinci-doc-001",
+            "text-search-curie-doc-001",
+            "text-search-babbage-doc-001",
+            "text-search-ada-doc-001",
+            "code-search-babbage-code-001",
+            "code-search-ada-code-001",
+            "gpt2"
+          ],
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Model",
+          "type": "string"
+        },
+        "text": {
+          "description": "Text to be split",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "model"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "texts"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "chunk_num": {
+          "description": "Total number of output text chunks",
+          "instillUIOrder": 2,
+          "title": "Number of Text Chunks",
+          "type": "integer"
+        },
+        "text_chunks": {
+          "description": "Text chunks after splitting",
+          "instillUIOrder": 1,
+          "items": {
+            "instillFormat": "string",
+            "instillMultiline": true,
+            "instillUIMultiline": true,
+            "type": "string"
+          },
+          "title": "Text Chunks",
+          "type": "array"
+        },
+        "token_count": {
+          "description": "Total count of tokens in the input text",
+          "instillUIOrder": 0,
+          "title": "Token Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "token_count",
+        "text_chunks",
+        "chunk_num"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  }
+}

--- a/pkg/text/main.go
+++ b/pkg/text/main.go
@@ -1,0 +1,91 @@
+package text
+
+import (
+	"fmt"
+	"sync"
+
+	_ "embed" // embed
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/component/pkg/base"
+)
+
+const (
+	taskTokenizerSplitter string = "TASK_TOKENIZER_SPLITTER"
+)
+
+var (
+	//go:embed config/definitions.json
+	definitionsJSON []byte
+	//go:embed config/tasks.json
+	tasksJSON []byte
+	once      sync.Once
+	operator  base.IOperator
+)
+
+// Operator is the derived operator
+type Operator struct {
+	base.Operator
+}
+
+// Execution is the derived execution
+type Execution struct {
+	base.Execution
+}
+
+// Init initializes the operator
+func Init(logger *zap.Logger) base.IOperator {
+	once.Do(func() {
+		operator = &Operator{
+			Operator: base.Operator{
+				Component: base.Component{Logger: logger},
+			},
+		}
+		err := operator.LoadOperatorDefinitions(definitionsJSON, tasksJSON, nil)
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+	})
+	return operator
+}
+
+// CreateExecution creates the derived execution
+func (o *Operator) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
+	e := &Execution{}
+	e.Execution = base.CreateExecutionHelper(e, o, defUID, task, config, logger)
+	return e, nil
+}
+
+// Execute executes the derived execution
+func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+	outputs := []*structpb.Struct{}
+
+	for _, input := range inputs {
+		switch e.Task {
+		case taskTokenizerSplitter:
+
+			inputStruct := TokenizerSplitterInput{}
+			err := base.ConvertFromStructpb(input, &inputStruct)
+			if err != nil {
+				return nil, err
+			}
+
+			outputStruct, err := splitTextIntoChunks(inputStruct)
+			if err != nil {
+				return nil, err
+			}
+			output, err := base.ConvertToStructpb(outputStruct)
+			if err != nil {
+				return nil, err
+			}
+			outputs = append(outputs, output)
+
+		default:
+			return nil, fmt.Errorf("not supported task: %s", e.Task)
+		}
+	}
+	return outputs, nil
+}

--- a/pkg/text/split.go
+++ b/pkg/text/split.go
@@ -1,0 +1,49 @@
+package text
+
+import (
+	"github.com/pkoukk/tiktoken-go"
+)
+
+const defaultChunkTokenSize = 500
+
+// TokenizerSplitterInput defines the input for the tokenizer splitter task
+type TokenizerSplitterInput struct {
+	// Text: Text to split
+	Text string `json:"text"`
+	// Model: ID of the model to use for tokenization
+	Model string `json:"model"`
+	// ChunkTokenSize: Number of tokens per text chunk
+	ChunkTokenSize *int `json:"chunk_token_size,omitempty"`
+}
+
+// TokenizerSplitterOutput defines the output for the tokenizer splitter task
+type TokenizerSplitterOutput struct {
+	// Texts: Text chunks
+	TokenCount int      `json:"token_count"`
+	TextChunks []string `json:"text_chunks"`
+	ChunkNum   int      `json:"chunk_num"`
+}
+
+// SplitTextIntoChunks splits text into text chunks based on token size
+func splitTextIntoChunks(input TokenizerSplitterInput) (TokenizerSplitterOutput, error) {
+	output := TokenizerSplitterOutput{}
+
+	if input.ChunkTokenSize == nil || *input.ChunkTokenSize <= 0 {
+		input.ChunkTokenSize = new(int)
+		*input.ChunkTokenSize = defaultChunkTokenSize
+	}
+
+	tkm, err := tiktoken.EncodingForModel(input.Model)
+	if err != nil {
+		return output, err
+	}
+
+	token := tkm.Encode(input.Text, nil, nil)
+	output.TokenCount = len(token)
+	for start := 0; start < len(token); start += *input.ChunkTokenSize {
+		end := min(start+*input.ChunkTokenSize, len(token))
+		output.TextChunks = append(output.TextChunks, tkm.Decode(token[start:end]))
+	}
+	output.ChunkNum = len(output.TextChunks)
+	return output, nil
+}

--- a/pkg/text/split_test.go
+++ b/pkg/text/split_test.go
@@ -1,0 +1,27 @@
+package text
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestTokenizerSplitter tests the tokenizer splitter task
+func TestTokenizerSplitter(t *testing.T) {
+	input := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"text":  {Kind: &structpb.Value_StringValue{StringValue: "Hello world. This is a test."}},
+			"model": {Kind: &structpb.Value_StringValue{StringValue: "gpt-3.5-turbo"}},
+		},
+	}
+	inputs := []*structpb.Struct{
+		input,
+	}
+
+	e := &Execution{}
+	e.Task = "TASK_TOKENIZER_SPLITTER"
+
+	if _, err := e.Execute(inputs); err != nil {
+		t.Fatalf("tokenizerSplitter returned an error: %v", err)
+	}
+}

--- a/pkg/textextraction/config/definitions.json
+++ b/pkg/textextraction/config/definitions.json
@@ -5,7 +5,7 @@
       "TASK_EXTRACT_FROM_PATH"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/operators/textextraction",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/textextraction",
     "icon": "textextraction.svg",
     "icon_url": "",
     "id": "op-textextraction",


### PR DESCRIPTION
Because

we want to support text splitting. This is useful when you want to split long text into chunks.

This commit

- add text operator with task `TASK_TOKENIZER_SPLITTER` that splits a text string into chunks using tokenizer by fixed token length   
