### PR TITLE
chore(all): use snake_case for all input variable naming style

### DIFF
--- a/pkg/end/config/tasks.json
+++ b/pkg/end/config/tasks.json
@@ -6,7 +6,7 @@
       "instillEditOnNodeFields": [],
       "instillUIOrder": 0,
       "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+        "^[a-z_][a-z_0-9]{0,31}$": {
           "description": "Arbitrary data",
           "instillAcceptFormats": [
             "*"
@@ -27,7 +27,7 @@
     "metadata": {
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+        "^[a-z_][a-z_0-9]{0,31}$": {
           "properties": {
             "description": {
               "type": "string"

--- a/pkg/start/config/tasks.json
+++ b/pkg/start/config/tasks.json
@@ -11,7 +11,7 @@
     "metadata": {
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+        "^[a-z_][a-z_0-9]{0,31}$": {
           "properties": {
             "description": {
               "type": "string"


### PR DESCRIPTION
Because

- we need to standardize the naming style of all ID

This commit

- use snake_case for all input variable naming style
