### PR TITLE
chore(all): allow hyphen in key

### DIFF
--- a/pkg/end/config/tasks.json
+++ b/pkg/end/config/tasks.json
@@ -6,7 +6,7 @@
       "instillEditOnNodeFields": [],
       "instillUIOrder": 0,
       "patternProperties": {
-        "^[a-z_][a-z_0-9]{0,31}$": {
+        "^[a-z_][-a-z_0-9]{0,31}$": {
           "description": "Arbitrary data",
           "instillAcceptFormats": [
             "*"
@@ -27,7 +27,7 @@
     "metadata": {
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-z_][a-z_0-9]{0,31}$": {
+        "^[a-z_][-a-z_0-9]{0,31}$": {
           "properties": {
             "description": {
               "type": "string"

--- a/pkg/start/config/tasks.json
+++ b/pkg/start/config/tasks.json
@@ -11,7 +11,7 @@
     "metadata": {
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-z_][a-z_0-9]{0,31}$": {
+        "^[a-z_][-a-z_0-9]{0,31}$": {
           "properties": {
             "description": {
               "type": "string"


### PR DESCRIPTION
Because

- we'd want to allow hyphen in the naming

This commit

- allow hyphen in key
