### PR TITLE
refactor(schema): refactor `structured/*` and `semi-structured/*`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Install operator dependencies
-        run: sudo apt-get install poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev -y
+        run: sudo apt-get update -y && sudo apt-get install poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev -y
 
       - uses: actions/checkout@v3
         with:

--- a/pkg/image/config/tasks.json
+++ b/pkg/image/config/tasks.json
@@ -5,7 +5,7 @@
       "instillUIOrder": 0,
       "properties": {
         "category": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/classification/properties/category",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/classification/properties/category",
           "instillAcceptFormats": [
             "string"
           ],
@@ -28,7 +28,7 @@
           "type": "string"
         },
         "score": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/classification/properties/score",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/classification/properties/score",
           "instillAcceptFormats": [
             "number",
             "integer"
@@ -100,9 +100,9 @@
           "type": "string"
         },
         "objects": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/detection/properties/objects",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/detection/properties/objects",
           "instillAcceptFormats": [
-            "structured/detection_objects"
+            "array:structured/detection_object"
           ],
           "instillUpstreamTypes": [
             "reference"
@@ -169,9 +169,9 @@
           "type": "string"
         },
         "objects": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/instance_segmentation/properties/objects",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/instance_segmentation/properties/objects",
           "instillAcceptFormats": [
-            "structured/instance_segmentation_objects"
+            "array:structured/instance_segmentation_object"
           ],
           "instillUpstreamTypes": [
             "reference"
@@ -238,9 +238,9 @@
           "type": "string"
         },
         "objects": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/keypoint/properties/objects",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/keypoint/properties/objects",
           "instillAcceptFormats": [
-            "structured/keypoint_objects"
+            "array:structured/keypoint_object"
           ],
           "instillUpstreamTypes": [
             "reference"
@@ -307,9 +307,9 @@
           "type": "string"
         },
         "objects": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/ocr/properties/objects",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/ocr/properties/objects",
           "instillAcceptFormats": [
-            "structured/ocr_objects"
+            "array:structured/ocr_object"
           ],
           "instillUpstreamTypes": [
             "reference"
@@ -389,9 +389,9 @@
           "type": "boolean"
         },
         "stuffs": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/semantic_segmentation/properties/stuffs",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/semantic_segmentation/properties/stuffs",
           "instillAcceptFormats": [
-            "structured/semantic_segmentation_stuffs"
+            "array:structured/semantic_segmentation_stuff"
           ],
           "instillUpstreamTypes": [
             "reference"

--- a/pkg/json/config/tasks.json
+++ b/pkg/json/config/tasks.json
@@ -10,7 +10,9 @@
         "object": {
           "description": "Json object to be marshaled",
           "instillAcceptFormats": [
-            "object"
+            "object",
+            "semi-structured/*",
+            "structured/*"
           ],
           "instillEditOnNodeFields": [],
           "instillUIOrder": 0,
@@ -90,7 +92,7 @@
         "object": {
           "description": "Object",
           "instillEditOnNodeFields": [],
-          "instillFormat": "application/json",
+          "instillFormat": "semi-structured/object",
           "instillUIOrder": 0,
           "required": [],
           "title": "Object",

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/instill-ai/operator/pkg/base64"
 	"github.com/instill-ai/operator/pkg/end"
 	"github.com/instill-ai/operator/pkg/image"
+	"github.com/instill-ai/operator/pkg/json"
 	"github.com/instill-ai/operator/pkg/start"
 	"github.com/instill-ai/operator/pkg/text"
 )
@@ -36,7 +37,7 @@ func Init(logger *zap.Logger) base.IOperator {
 		operator.(*Operator).ImportDefinitions(base64.Init(logger))
 		operator.(*Operator).ImportDefinitions(start.Init(logger))
 		operator.(*Operator).ImportDefinitions(end.Init(logger))
-		// operator.(*Operator).ImportDefinitions(json.Init(logger))
+		operator.(*Operator).ImportDefinitions(json.Init(logger))
 		operator.(*Operator).ImportDefinitions(image.Init(logger))
 		operator.(*Operator).ImportDefinitions(text.Init(logger))
 

--- a/pkg/text/config/tasks.json
+++ b/pkg/text/config/tasks.json
@@ -49,7 +49,7 @@
         },
         "meta": {
           "description": "Metadata extracted from the document",
-          "instillFormat": "application/json",
+          "instillFormat": "semi-structured/object",
           "instillUIOrder": 1,
           "required": [],
           "title": "Meta",


### PR DESCRIPTION
Because

- we need to mark instillFormat in the array item as well
- we need a new instillFormat for object type data

This commit

- refactor instillFormat `structured/*`
- add `semi-structured/object` format for json object data
