### PR TITLE
chore: update icon paths

### DIFF
--- a/pkg/base64/config/definitions.json
+++ b/pkg/base64/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/base64",
-    "icon": "base64.svg",
+    "icon": "Instill AI/base64.svg",
     "icon_url": "",
     "id": "base64",
     "public": true,

--- a/pkg/end/config/definitions.json
+++ b/pkg/end/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/op-end",
-    "icon": "end.svg",
+    "icon": "Instill AI/end.svg",
     "icon_url": "",
     "id": "end",
     "public": true,

--- a/pkg/image/config/definitions.json
+++ b/pkg/image/config/definitions.json
@@ -10,7 +10,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/image",
-    "icon": "image.svg",
+    "icon": "Instill AI/image.svg",
     "icon_url": "",
     "id": "image",
     "public": true,

--- a/pkg/json/config/definitions.json
+++ b/pkg/json/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/json",
-    "icon": "json.svg",
+    "icon": "Instill AI/json.svg",
     "icon_url": "",
     "id": "json",
     "public": true,

--- a/pkg/start/config/definitions.json
+++ b/pkg/start/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/op-start",
-    "icon": "start.svg",
+    "icon": "Instill AI/start.svg",
     "icon_url": "",
     "id": "start",
     "public": true,

--- a/pkg/text/config/definitions.json
+++ b/pkg/text/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/text",
-    "icon": "text.svg",
+    "icon": "Instill AI/text.svg",
     "icon_url": "",
     "id": "text",
     "public": true,


### PR DESCRIPTION
Because

- Currently, the console uses `vendor` and `id` to locate the icon image. However, there is actually an `icon` field in the definition response, and we should utilize it.

This commit

- update icon paths
