### PR TITLE
feat(json): use `semi-structured/json` in TASK_MARSHAL and TASK_UNMARSHAL

### DIFF
--- a/pkg/json/v0/config/tasks.json
+++ b/pkg/json/v0/config/tasks.json
@@ -1,15 +1,15 @@
 {
   "TASK_MARSHAL": {
-    "instillShortDescription": "Marshal the JSON object into string.",
+    "instillShortDescription": "Convert JSON to a string.",
     "input": {
       "description": "Input",
       "instillEditOnNodeFields": [
-        "object"
+        "json"
       ],
       "instillUIOrder": 0,
       "properties": {
-        "object": {
-          "description": "Json object to be marshaled",
+        "json": {
+          "description": "JSON to be marshaled",
           "instillAcceptFormats": [
             "object",
             "semi-structured/*",
@@ -21,12 +21,11 @@
             "reference"
           ],
           "required": [],
-          "title": "Object",
-          "type": "object"
+          "title": "JSON"
         }
       },
       "required": [
-        "object"
+        "json"
       ],
       "title": "Input",
       "type": "object"
@@ -55,7 +54,7 @@
     }
   },
   "TASK_UNMARSHAL": {
-    "instillShortDescription": "Unmarshal the JSON object from string.",
+    "instillShortDescription": "Convert a string to JSON.",
     "input": {
       "description": "Input",
       "instillEditOnNodeFields": [
@@ -87,22 +86,21 @@
     "output": {
       "description": "Output",
       "instillEditOnNodeFields": [
-        "object"
+        "json"
       ],
       "instillUIOrder": 0,
       "properties": {
-        "object": {
+        "json": {
           "description": "Object",
           "instillEditOnNodeFields": [],
-          "instillFormat": "semi-structured/object",
+          "instillFormat": "semi-structured/json",
           "instillUIOrder": 0,
           "required": [],
-          "title": "Object",
-          "type": "object"
+          "title": "JSON"
         }
       },
       "required": [
-        "object"
+        "json"
       ],
       "title": "Output",
       "type": "object"

--- a/pkg/json/v0/main.go
+++ b/pkg/json/v0/main.go
@@ -63,7 +63,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 		output := structpb.Struct{Fields: make(map[string]*structpb.Value)}
 		switch e.Task {
 		case marshal:
-			b, err := protojson.Marshal(input.Fields["object"])
+			b, err := protojson.Marshal(input.Fields["json"])
 			if err != nil {
 				return nil, err
 			}
@@ -74,7 +74,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			output.Fields["object"] = structpb.NewStructValue(&obj)
+			output.Fields["json"] = structpb.NewStructValue(&obj)
 
 		default:
 			return nil, fmt.Errorf("not supported task: %s", e.Task)


### PR DESCRIPTION
Because

- We've introduced `semi-structured/json` for handling JSON data.

This commit

- Utilizes `semi-structured/json` in TASK_MARSHAL and TASK_UNMARSHAL.
- Refines the task descriptions.

Note
- This commit is a breaking change.