### PR TITLE
fix: add missing `array:` instillFormat in operator output

### DIFF
--- a/pkg/json/v0/config/tasks.json
+++ b/pkg/json/v0/config/tasks.json
@@ -162,7 +162,7 @@
           "required": [],
           "title": "Results",
           "type": "array",
-          "instillFormat": "semi-structured/json",
+          "instillFormat": "array:semi-structured/json",
           "items": {
             "instillFormat": "semi-structured/json"
           }

--- a/pkg/text/v0/config/tasks.json
+++ b/pkg/text/v0/config/tasks.json
@@ -185,6 +185,7 @@
         "text_chunks": {
           "description": "Text chunks after splitting",
           "instillUIOrder": 1,
+          "instillFormat": "array:string",
           "items": {
             "instillFormat": "string",
             "instillUIMultiline": true,


### PR DESCRIPTION
Because

- The console can't display the correct `array` label due to the lack of an array-type `instillFormat`.

This commit

- Adds the missing array-type `instillFormat` in the operator output definition.