### PR TITLE
chore: add release_stage property to definitions

### DIFF
--- a/pkg/base64/v0/config/definitions.json
+++ b/pkg/base64/v0/config/definitions.json
@@ -16,6 +16,7 @@
     "uid": "3a836447-c211-4134-9cc5-ad45e1cc467e",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/base64/v0",
-    "description": "Encode or decode a string in Base64 format"
+    "description": "Encode or decode a string in Base64 format",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/end/v0/config/definitions.json
+++ b/pkg/end/v0/config/definitions.json
@@ -15,6 +15,7 @@
     "uid": "4f39c8bc-8617-495d-80de-80d0f5397516",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/end/v0",
-    "description": "Create an output interface in a pipeline when triggered synchronously"
+    "description": "Create an output interface in a pipeline when triggered synchronously",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/image/v0/config/definitions.json
+++ b/pkg/image/v0/config/definitions.json
@@ -19,6 +19,7 @@
     "uid": "e9eb8fc8-f249-4e11-ad50-5035d79ffc18",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/image/v0",
-    "description": "Manipulate image files"
+    "description": "Manipulate image files",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/json/v0/config/definitions.json
+++ b/pkg/json/v0/config/definitions.json
@@ -16,6 +16,7 @@
     "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/json/v0",
-    "description": "Manipulate and convert JSON objects"
+    "description": "Manipulate and convert JSON objects",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/start/v0/config/definitions.json
+++ b/pkg/start/v0/config/definitions.json
@@ -15,6 +15,7 @@
     "uid": "2ac8be70-0f7a-4b61-a33d-098b8acfa6f3",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/start/v0",
-    "description": "Define data formats customized for their AI-first applications"
+    "description": "Define data formats customized for their AI-first applications",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/text/v0/config/definitions.json
+++ b/pkg/text/v0/config/definitions.json
@@ -15,6 +15,7 @@
     "uid": "5b7aca5b-1ae3-477f-bf60-d34e1c993c87",
     "version": "0.1.0-alpha",
     "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/text/v0",
-    "description": "Extract and manipulate text from different sources"
+    "description": "Extract and manipulate text from different sources",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]


### PR DESCRIPTION
Because

- With https://github.com/instill-ai/pipeline-backend/pull/414 the `release_stage` property will be displayed and filtered by in the component definition lists.

This commit

- Adds the release property for the existing operators

## Next steps ⏭️ 

- This field, along with others, will be documented so it is clear how to set it in new contributions.
- In the console connector and operator lists, unimplemented components will be hidden.
