### PR TITLE
fix(text): fix nil meta issue for txt file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
-	github.com/otiai10/gosseract/v2 v2.2.4 // indirect
+	github.com/otiai10/gosseract/v2 v2.4.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/richardlehane/mscfb v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,11 +87,10 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/gosseract/v2 v2.2.4 h1:h/PV+oJqke8q2Ccw9bjpMBWfd7N2vtGDCUcihZj3nRo=
-github.com/otiai10/gosseract/v2 v2.2.4/go.mod h1:ahOp/kHojnOMGv1RaUnR0jwY5JVa6BYKhYAS8nbMLSo=
-github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/gosseract/v2 v2.4.1 h1:G8AyBpXEeSlcq8TI85LH/pM5SXk8Djy2GEXisgyblRw=
+github.com/otiai10/gosseract/v2 v2.4.1/go.mod h1:1gNWP4Hgr2o7yqWfs6r5bZxAatjOIdqWxJLWsTsembk=
+github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=
+github.com/otiai10/mint v1.6.3/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/text/v0/convert.go
+++ b/pkg/text/v0/convert.go
@@ -60,6 +60,10 @@ func convertToText(input ConvertToTextInput) (ConvertToTextOutput, error) {
 		return ConvertToTextOutput{}, err
 	}
 
+	if res.Meta == nil {
+		res.Meta = map[string]string{}
+	}
+
 	return ConvertToTextOutput{
 		Body:  res.Body,
 		Meta:  res.Meta,

--- a/pkg/text/v0/convert_test.go
+++ b/pkg/text/v0/convert_test.go
@@ -50,6 +50,10 @@ func TestConvertToText(t *testing.T) {
 			name:     "Convert tiff file",
 			filepath: "testdata/test.tif",
 		},
+		{
+			name:     "Convert txt file",
+			filepath: "testdata/test.txt",
+		},
 	}
 
 	for _, test := range tests {
@@ -79,7 +83,10 @@ func TestConvertToText(t *testing.T) {
 				t.Fatalf("convertToText returned an error: %v", err)
 			} else if outputs[0].Fields["body"].GetStringValue() == "" {
 				t.Fatal("convertToText returned an empty body")
+			} else if outputs[0].Fields["meta"].GetStructValue() == nil {
+				t.Fatal("convertToText returned a nil meta")
 			}
+
 		})
 	}
 

--- a/pkg/text/v0/testdata/test.txt
+++ b/pkg/text/v0/testdata/test.txt
@@ -1,0 +1,58 @@
+
+👋 Welcome!
+Website ▪︎ Blog ▪︎ Discord ▪︎ X
+Instill AI is on a mission to make AI highly accessible to everyone. We've been hard at work developing tools that simplify the process of unlocking value from unstructured data across all layers of the modern data stack. This means that organizations of all sizes can benefit from our endeavors. For a deeper dive into our vision, check out our blog post on Why Instill AI exists.
+
+What Are We Building?
+We're dedicated to bringing AI into the modern data stack by solving unstructured data ETL. Our tools are built on an open and maintainable framework, designed to empower communities to benefit and actively engage.
+
+Instill Core: Open-source Unstructured Data Infrastructure Stack
+Explore our open-source unstructured data infrastructure stack, comprising a collection of source-available projects designed to streamline every aspect of building versatile AI features with unstructured data. Dive into the potential in our documentation.
+
+🔮 Instill Core: The foundation for self-hosting Instill VDP and Instill Model
+
+Instill Core, or simply Core, is the foundation of our open-source unstructured data stack. It houses essential services like user management servers, databases, and third-party observability tools. Instill Core also provides deployment codes to facilitate the seamless launch of both Instill VDP and Instill Model.
+
+💧 Instill VDP: AI pipeline builder for unstructured data
+
+Instill VDP, or VDP (Versatile Data Pipeline), represents a comprehensive unstructured data infrastructure. Its purpose is to simplify the journey of processing unstructured data from start to finish:
+
+Extract: Gather unstructured data from diverse sources, including AI applications, cloud/on-prem storage, and IoT devices.
+Transform: Utilize AI models to convert raw data into meaningful insights and actionable formats.
+Load: Efficiently move processed data to warehouses, applications, or other destinations.
+Embracing VDP is straightforward, whether you opt for Instill Cloud deployment or self-hosting via Instill Core. Consult our comprehensive documentation to delve into VDP deployment.
+
+⚗️ Instill Model: Scalable AI model serving and training
+
+Instill Model, or simply Model, emerges as an advanced ModelOps platform. Here, the focus is on empowering you to seamlessly import, train and serve Machine Learning (ML) models for inference purposes. Like other projects, Instill Model's source code is available for your exploration.
+
+Instill Cloud
+Not quite into self-hosting? We've got you covered with ☁️ Instill Cloud! It's a fully-managed public cloud service that grants you access to all the fantastic features of the open-source unstructured data infrastructure stack, without the hassle of managing infrastructure. We're currently in the exciting Open Alpha testing phase, and all features are FREE during this period! 🎉
+
+No-Code/Low-Code Access
+To dive into Instill Core and Instill Cloud, you have a few options:
+
+Note To access Instill Cloud, register an account with your email address.
+
+⛅ Instill Console: Dive in Instill Core/Cloud with no coding
+
+Instill Console, or Console is a user-friendly web-based UI application that improves accessibility and usability across both Instill Core and Instill Cloud. It allows you to dive into the creation of AI apps or the processing of unstructured data without the need for coding skills.
+
+To access the Instill Core console, please launch Instill Core and navigate to http://localhost:3000. For the Instill Cloud console, simply go to https://console.instill.tech.
+
+📺 Instill CLI: Bring Instill Core/Cloud to your command line
+
+Instill CLI enables you to access Instill Core and Instill Cloud from your terminal. It can be installed by brew install instill-ai/tap/inst for Linux and macOS. To set up and get started with Instill CLI, head over to here.
+
+📦 Instill SDKs: Integrate Instill Core/Cloud with your language of choice
+
+Instill SDKs make it easy for developers to integrate and interact with Instill Core and Cloud.
+
+Python SDK
+TypeScript SDK
+Stay tuned, as more SDKs are on the way!
+Be Part of Our Community and Make a Difference
+🙌 We strongly believe in the power of community collaboration and deeply value your contributions.
+
+Head over to our Community repository, the central hub for discussing our open-source projects, raising issues, and sharing your brilliant ideas.
+Join our Discord server to exchange ideas about unstructured data processing, AI, MLOps, and get support from the Instill AI team. We're here to support you every step of the way!


### PR DESCRIPTION
Because

- by default `decconv` doesn't define a `meta` field for `.txt` file (see [here](https://github.com/sajari/docconv/blob/master/docconv.go#L98-L102))
- this causes the meta field return `nil` from the Text operator causing the `pipeline-backend` reporting error.

This commit

- add a safety check for the returned `meta` field in the conversion result
